### PR TITLE
Update amazon machine image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/googleapis/gnostic v0.5.1 // indirect
-	github.com/networkservicemesh/integration-tests v0.0.0-20220125070535-4b340c519f0f
+	github.com/networkservicemesh/integration-tests v0.0.0-20220127235218-8067ea51630e
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/networkservicemesh/gotestmd v0.0.0-20211116145945-871d2aaf07ab h1:/dIr8Nky77grI3s9Rc78eFH9M1Svobyj2XJBaKm27ts=
 github.com/networkservicemesh/gotestmd v0.0.0-20211116145945-871d2aaf07ab/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
-github.com/networkservicemesh/integration-tests v0.0.0-20220125070535-4b340c519f0f h1:ePEiyrEO8BK46MlBWqEhjnZDGnSrie3woQvkzpFiLm4=
-github.com/networkservicemesh/integration-tests v0.0.0-20220125070535-4b340c519f0f/go.mod h1:0o7WrzxlHEwnDSuZPEM1BnKd4hr7+akKgymoAoTTbv8=
+github.com/networkservicemesh/integration-tests v0.0.0-20220127235218-8067ea51630e h1:wr97ockMQd8ZhBfNiYW4yiuNe+Hmosqv4IkPNbyhxiY=
+github.com/networkservicemesh/integration-tests v0.0.0-20220127235218-8067ea51630e/go.mod h1:0o7WrzxlHEwnDSuZPEM1BnKd4hr7+akKgymoAoTTbv8=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/scripts/create-kubernetes-cluster.go
+++ b/scripts/create-kubernetes-cluster.go
@@ -221,11 +221,8 @@ func (ac *AWSCluster) createEksWorkerNodes(cfClient *cloudformation.CloudFormati
 
 	s := string(sf)
 
-	// Base image for Amazon EKS worker nodes
-	// with Kubernetes version 1.14.7
-	// for region us-east-2.
 	// Amazon EKS-Optimized AMI list: https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
-	eksAmi := aws.String("ami-053250833d1030033")
+	eksAmi := aws.String("ami-014b0ee6a978b6ca5")
 
 	_, err = cfClient.CreateStack(&cloudformation.CreateStackInput{
 		StackName:       nodesStackName,


### PR DESCRIPTION
Closes: https://github.com/networkservicemesh/integration-k8s-aws/pull/248

The previous image version uses old kernel version (`v4.14`) where the part of `ip rule` functionality is not available (like `ipproto`, `sport`, `dport` ...).